### PR TITLE
Update `Collection` nomenclature to be more explicit

### DIFF
--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -23,12 +23,12 @@ contract DelegationRegistry {
     /** 
     * @notice Emitted when a user delegates a specific contract address
     */ 
-    event DelegateForContract(address vault, address delegate, bytes32 role, address contract, bool value);
+    event DelegateForContract(address vault, address delegate, bytes32 role, address contract_, bool value);
 
     /** 
     * @notice Emitted when a user delegates a specific token
     */
-    event DelegateForToken(address vault, address delegate, bytes32 role, address contract, uint256 tokenId, bool value);
+    event DelegateForToken(address vault, address delegate, bytes32 role, address contract_, uint256 tokenId, bool value);
 
     /** -----------  WRITE ----------- */
 
@@ -49,29 +49,29 @@ contract DelegationRegistry {
     * @notice Allow the delegate to act on your behalf for a specific NFT contract
     * @param delegate The hotwallet to act on your behalf
     * @param role The role for delegations, default is 0x0000000000000000000000000000000000000000000000000000000000000000
-    * @param contract The address for the contract you're delegating
+    * @param contract_ The address for the contract you're delegating
     * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
     */
 
-    function delegateForContract(address delegate, bytes32 role, address contract, bool value) external {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, role, msg.sender, contract));
+    function delegateForContract(address delegate, bytes32 role, address contract_, bool value) external {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, role, msg.sender, contract_));
         delegations[delegateHash] = value;
-        emit DelegateForContract(msg.sender, delegate, role, contract, value);
+        emit DelegateForContract(msg.sender, delegate, role, contract_, value);
     }
 
     /** 
     * @notice Allow the delegate to act on your behalf for a specific token, supports 721 and 1155
     * @param delegate The hotwallet to act on your behalf
     * @param role The role for delegations, default is 0x0000000000000000000000000000000000000000000000000000000000000000
-    * @param contract The contract address that the token you're delegating belongs to
+    * @param contract_ The contract address that the token you're delegating belongs to
     * @param tokenId The token id for the token you're delegating
     * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
     */    
 
-    function delegateForToken(address delegate, bytes32 role, address contract, uint256 tokenId, bool value) external {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, role, msg.sender, contract, tokenId));
+    function delegateForToken(address delegate, bytes32 role, address contract_, uint256 tokenId, bool value) external {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, role, msg.sender, contract_, tokenId));
         delegations[delegateHash] = value;
-        emit DelegateForToken(msg.sender, delegate, role, contract, tokenId, value);
+        emit DelegateForToken(msg.sender, delegate, role, contract_, tokenId, value);
     }
 
     /** -----------  READ ----------- */
@@ -92,12 +92,12 @@ contract DelegationRegistry {
     * @notice Returns true if the address is delegated to act on your behalf for an NFT contract
     * @param delegate The hotwallet to act on your behalf
     * @param role The role for delegations, default is 0x0000000000000000000000000000000000000000000000000000000000000000
-    * @param contract The address for the contract you're delegating
+    * @param contract_ The address for the contract you're delegating
     * @param vault The cold wallet who issued the delegation
     */
         
-    function checkDelegateForContract(address delegate, bytes32 role, address vault, address contract) public view returns (bool) {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, role, vault, contract));
+    function checkDelegateForContract(address delegate, bytes32 role, address vault, address contract_) public view returns (bool) {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, role, vault, contract_));
         return delegations[delegateHash] ? true : checkDelegateForAll(delegate, role, vault);
     }
     
@@ -105,13 +105,13 @@ contract DelegationRegistry {
     * @notice Returns true if the address is delegated to act on your behalf for an specific NFT
     * @param delegate The hotwallet to act on your behalf
     * @param role The role for delegations, default is 0x0000000000000000000000000000000000000000000000000000000000000000
-    * @param contract The contract address that the token you're delegating belongs to
+    * @param contract_ The contract address that the token you're delegating belongs to
     * @param tokenId The token id for the token you're delegating
     * @param vault The cold wallet who issued the delegation
     */
 
-    function checkDelegateForToken(address delegate, bytes32 role, address vault, address contract, uint256 tokenId) public view returns (bool) {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, role, vault, contract, tokenId));
-        return delegations[delegateHash] ? true : checkDelegateForContract(delegate, role, vault, contract);
+    function checkDelegateForToken(address delegate, bytes32 role, address vault, address contract_, uint256 tokenId) public view returns (bool) {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, role, vault, contract_, tokenId));
+        return delegations[delegateHash] ? true : checkDelegateForContract(delegate, role, vault, contract_);
     }
 }

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -21,14 +21,14 @@ contract DelegationRegistry {
     event DelegateForAll(address vault, address delegate, bytes32 role, bool value);
     
     /** 
-    * @notice Emitted when a user delegates a specific collection
+    * @notice Emitted when a user delegates a specific contract address
     */ 
-    event DelegateForCollection(address vault, address delegate, bytes32 role, address collection, bool value);
+    event DelegateForContract(address vault, address delegate, bytes32 role, address contract, bool value);
 
     /** 
     * @notice Emitted when a user delegates a specific token
     */
-    event DelegateForToken(address vault, address delegate, bytes32 role, address collection, uint256 tokenId, bool value);
+    event DelegateForToken(address vault, address delegate, bytes32 role, address contract, uint256 tokenId, bool value);
 
     /** -----------  WRITE ----------- */
 
@@ -46,32 +46,32 @@ contract DelegationRegistry {
     }
 
     /** 
-    * @notice Allow the delegate to act on your behalf for a specific NFT collection
+    * @notice Allow the delegate to act on your behalf for a specific NFT contract
     * @param delegate The hotwallet to act on your behalf
     * @param role The role for delegations, default is 0x0000000000000000000000000000000000000000000000000000000000000000
-    * @param collection The contract address for the collection you're delegating
+    * @param contract The address for the contract you're delegating
     * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
     */
 
-    function delegateForCollection(address delegate, bytes32 role, address collection, bool value) external {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, role, msg.sender, collection));
+    function delegateForContract(address delegate, bytes32 role, address contract, bool value) external {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, role, msg.sender, contract));
         delegations[delegateHash] = value;
-        emit DelegateForCollection(msg.sender, delegate, role, collection, value);
+        emit DelegateForContract(msg.sender, delegate, role, contract, value);
     }
 
     /** 
     * @notice Allow the delegate to act on your behalf for a specific token, supports 721 and 1155
     * @param delegate The hotwallet to act on your behalf
     * @param role The role for delegations, default is 0x0000000000000000000000000000000000000000000000000000000000000000
-    * @param collection The contract address for the collection you're delegating
+    * @param contract The contract address that the token you're delegating belongs to
     * @param tokenId The token id for the token you're delegating
     * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
     */    
 
-    function delegateForToken(address delegate, bytes32 role, address collection, uint256 tokenId, bool value) external {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, role, msg.sender, collection, tokenId));
+    function delegateForToken(address delegate, bytes32 role, address contract, uint256 tokenId, bool value) external {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, role, msg.sender, contract, tokenId));
         delegations[delegateHash] = value;
-        emit DelegateForToken(msg.sender, delegate, role, collection, tokenId, value);
+        emit DelegateForToken(msg.sender, delegate, role, contract, tokenId, value);
     }
 
     /** -----------  READ ----------- */
@@ -89,15 +89,15 @@ contract DelegationRegistry {
     }
 
     /** 
-    * @notice Returns true if the address is delegated to act on your behalf for an NFT collection
+    * @notice Returns true if the address is delegated to act on your behalf for an NFT contract
     * @param delegate The hotwallet to act on your behalf
     * @param role The role for delegations, default is 0x0000000000000000000000000000000000000000000000000000000000000000
-    * @param collection The contract address for the collection you're delegating
+    * @param contract The address for the contract you're delegating
     * @param vault The cold wallet who issued the delegation
     */
         
-    function checkDelegateForCollection(address delegate, bytes32 role, address vault, address collection) public view returns (bool) {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, role, vault, collection));
+    function checkDelegateForContract(address delegate, bytes32 role, address vault, address contract) public view returns (bool) {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, role, vault, contract));
         return delegations[delegateHash] ? true : checkDelegateForAll(delegate, role, vault);
     }
     
@@ -105,13 +105,13 @@ contract DelegationRegistry {
     * @notice Returns true if the address is delegated to act on your behalf for an specific NFT
     * @param delegate The hotwallet to act on your behalf
     * @param role The role for delegations, default is 0x0000000000000000000000000000000000000000000000000000000000000000
-    * @param collection The contract address for the collection you're delegating
+    * @param contract The contract address that the token you're delegating belongs to
     * @param tokenId The token id for the token you're delegating
     * @param vault The cold wallet who issued the delegation
     */
 
-    function checkDelegateForToken(address delegate, bytes32 role, address vault, address collection, uint256 tokenId) public view returns (bool) {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, role, vault, collection, tokenId));
-        return delegations[delegateHash] ? true : checkDelegateForCollection(delegate, role, vault, collection);
+    function checkDelegateForToken(address delegate, bytes32 role, address vault, address contract, uint256 tokenId) public view returns (bool) {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, role, vault, contract, tokenId));
+        return delegations[delegateHash] ? true : checkDelegateForContract(delegate, role, vault, contract);
     }
 }

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -18,32 +18,32 @@ contract DelegationRegistryTest is Test {
         vm.startPrank(vault);
         reg.delegateForAll(delegate, true);
         assertTrue(reg.checkDelegateForAll(delegate, vault));
-        assertTrue(reg.checkDelegateForCollection(delegate, vault, address(0x0)));
+        assertTrue(reg.checkDelegateForContract(delegate, vault, address(0x0)));
         assertTrue(reg.checkDelegateForToken(delegate, vault, address(0x0), 0));
         // Revoke
         reg.delegateForAll(delegate, false);
         assertFalse(reg.checkDelegateForAll(delegate, vault));
     }
 
-    function testApproveAndRevokeForCollection(address vault, address delegate, address collection) public {
+    function testApproveAndRevokeForContract(address vault, address delegate, address contract_) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForCollection(delegate, collection, true);
-        assertTrue(reg.checkDelegateForCollection(delegate, vault, collection));
-        assertTrue(reg.checkDelegateForToken(delegate, vault, collection, 0));
+        reg.delegateForContract(delegate, contract_, true);
+        assertTrue(reg.checkDelegateForContract(delegate, vault, contract_));
+        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, 0));
         // Revoke
-        reg.delegateForCollection(delegate, collection, false);
-        assertFalse(reg.checkDelegateForCollection(delegate, vault, collection));
+        reg.delegateForContract(delegate, contract_, false);
+        assertFalse(reg.checkDelegateForContract(delegate, vault, contract_));
     }
 
-    function testApproveAndRevokeForToken(address vault, address delegate, address collection, uint256 tokenId) public {
+    function testApproveAndRevokeForToken(address vault, address delegate, address contract_, uint256 tokenId) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForToken(delegate, collection, tokenId, true);
-        assertTrue(reg.checkDelegateForToken(delegate, vault, collection, tokenId));
+        reg.delegateForToken(delegate, contract_, tokenId, true);
+        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
         // Revoke
-        reg.delegateForToken(delegate, collection, tokenId, false);
-        assertFalse(reg.checkDelegateForToken(delegate, vault, collection, tokenId));
+        reg.delegateForToken(delegate, contract_, tokenId, false);
+        assertFalse(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
     }
 
     function testMultipleDelegationForAll(address vault, address delegate0, address delegate1) public {


### PR DESCRIPTION
This updates the nomenclature of `Collection` to use the more explicit nomenclature of `Contract` as there are often contracts that have multiple different collections/projects within them (e.g. Art Blocks, various partner platforms powered by the Art Blocks Engine, SuperRare, Foundation, etc.), and while I don't think it makes sense for this registry to be aware of the nuances of how various contracts handle the abstraction of "collection" or "project", I do think that the nomenclature used by the registry should be as explicit here as possible to avoid any opportunity for developer / user error due to confusion.