### PR TITLE
Allow delegate to revoke themselves

### DIFF
--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -92,16 +92,27 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         emit IDelegationRegistry.RevokeAllDelegates(msg.sender);
     }
 
-     /**
+    /**
     * See {IDelegationRegistry-revokeDelegate}.
     */
     function revokeDelegate(address delegate) external override {
-        delegateVersion[msg.sender][delegate]++;
+        _revokeDelegate(delegate, msg.sender);
+    }
+
+    /**
+    * See {IDelegationRegistry-revokeSelf}.
+    */
+    function revokeSelf(address vault) external override {
+        _revokeDelegate(msg.sender, vault);
+    }
+
+    function _revokeDelegate(address delegate, address vault) internal {
+        delegateVersion[vault][delegate]++;
         // Remove delegate from enumerations
-        delegationsForAll[msg.sender][vaultVersion[msg.sender]].remove(delegate);
+        delegationsForAll[vault][vaultVersion[vault]].remove(delegate);
         // For delegationsForContract and delegationsForToken, filter in the view
         // functions
-        emit IDelegationRegistry.RevokeDelegate(msg.sender, delegate);
+        emit IDelegationRegistry.RevokeDelegate(vault, msg.sender);
     }
 
     /** -----------  READ ----------- */

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -61,6 +61,11 @@ interface IDelegationRegistry {
      */
     function revokeDelegate(address delegate) external;
 
+    /**
+     * @notice Revoke delegation for a specific vault, for all permissions
+     */
+    function revokeSelf(address vault) external;
+
     /** -----------  READ ----------- */
 
     /**

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -133,4 +133,38 @@ contract DelegationRegistryTest is Test {
         assertFalse(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
         assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
     }
+
+    function testRevokeSelf(address vault, address delegate0, address delegate1, address contract_, uint256 tokenId) public {
+        vm.assume(vault != delegate0);
+        vm.assume(delegate0 != delegate1);
+        vm.startPrank(vault);
+        reg.delegateForAll(delegate0, true);
+        reg.delegateForContract(delegate0, contract_, true);
+        reg.delegateForToken(delegate0, contract_, tokenId, true);
+        reg.delegateForAll(delegate1, true);
+        reg.delegateForContract(delegate1, contract_, true);
+        reg.delegateForToken(delegate1, contract_, tokenId, true);
+        
+        // delegate 0 revoke self from being a delegate for vault
+        changePrank(delegate0);
+        reg.revokeSelf(vault);
+        vm.stopPrank();
+        // Read
+        address[] memory vaultDelegatesForAll = reg.getDelegationsForAll(vault);
+        assertEq(vaultDelegatesForAll.length, 1);
+        assertEq(vaultDelegatesForAll[0], delegate1);
+        address[] memory vaultDelegatesForContract = reg.getDelegationsForContract(vault, contract_);
+        assertEq(vaultDelegatesForContract.length, 1);
+        assertEq(vaultDelegatesForContract[0], delegate1);
+        address[] memory vaultDelegatesForToken = reg.getDelegationsForToken(vault, contract_, tokenId);
+        assertEq(vaultDelegatesForToken.length, 1);
+        assertEq(vaultDelegatesForToken[0], delegate1);
+
+        assertFalse(reg.checkDelegateForAll(delegate0, vault));
+        assertTrue(reg.checkDelegateForAll(delegate1, vault));
+        assertFalse(reg.checkDelegateForContract(delegate0, vault, contract_));
+        assertTrue(reg.checkDelegateForContract(delegate1, vault, contract_));
+        assertFalse(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
+        assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
+    }
 }


### PR DESCRIPTION
Allow delegate to revoke themselves as a delegate for a specific vault.

This enables the vault owner to revoke delegation from the delegate wallet itself, eliminating the requirement to bring a vault out of cold storage.

## Additional Considerations
We could enable any delegate to revoke all delegations for a given vault. However, allowing delegates to affect other delegates seems like a bad design because it gives too much power to a single delegate.

Cc @jakerockland 